### PR TITLE
fix(engine): remove documented-but-broken runtime kwargs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -91,9 +91,15 @@ engine.parse(text, exclude=["cities"])  # everything but cities
 | `search(text)` | first `Match` or `None` | same as `parse` |
 | `finditer(text)` | lazy `Iterator[Match]` | raw, unpurged |
 
-All three accept the same keyword arguments and forward the extras
-(`pos`, `endpos`, `partial`, `timeout`, …) to
-[`regex.finditer`](https://github.com/mrabarnett/mrab-regex/blob/hg/docs/Features.md).
+All three accept the same keyword arguments and forward the match-time extras
+(`pos`, `endpos`, `overlapped`, `partial`, `concurrent`, `timeout`) to
+[`regex`](https://github.com/mrabarnett/mrab-regex/blob/hg/docs/Features.md).
+
+```{note}
+Regex `flags` are a **compile-time** setting: pass them once when constructing the
+engine (`Replus("patterns", flags=regex.IGNORECASE)`). They cannot be given per call,
+because the patterns are already compiled by then.
+```
 
 ## Replacing inside matches
 

--- a/src/replus/engine.py
+++ b/src/replus/engine.py
@@ -60,13 +60,10 @@ class Replus:
         exclude: list[str] | None = None,
         pos: int | None = None,
         endpos: int | None = None,
-        flags: int = 0,
         overlapped: bool = False,
         partial: bool = False,
         concurrent: bool | None = None,
         timeout: float | None = None,
-        ignore_unused: bool = False,
-        **kwargs: Any,
     ) -> Iterator[Match]:
         """Lazily yield every match of every (selected) pattern, in pattern order.
 
@@ -79,32 +76,30 @@ class Replus:
             exclude: Skip patterns of these types.
             pos: Start position of the matching.
             endpos: End position of the matching.
-            flags: Extra flags forwarded to :func:`regex.finditer`.
             overlapped: Allow overlapping matches of the same pattern.
             partial: Allow partial matches.
             concurrent: Release the GIL while matching.
             timeout: Timeout in seconds for the matching.
-            ignore_unused: Ignore unused positional or keyword arguments in ``kwargs``.
-            **kwargs: Any further arguments accepted by :func:`regex.finditer`.
 
         Yields:
             One :class:`~replus.results.Match` per raw regex match.
+
+        Note:
+            Regex ``flags`` are a compile-time setting: pass them once to
+            :class:`Replus` (``Replus(..., flags=regex.IGNORECASE)``). They cannot be
+            supplied per call, because the patterns are already compiled.
         """
         for compiled in self.patterns:
             if (filters and compiled.type not in filters) or (exclude and compiled.type in exclude):
                 continue
-            for match in regex.finditer(
-                pattern=compiled.regex,
-                string=string,
-                flags=flags,
+            for match in compiled.regex.finditer(
+                string,
                 pos=pos,
                 endpos=endpos,
                 overlapped=overlapped,
                 partial=partial,
                 concurrent=concurrent,
                 timeout=timeout,
-                ignore_unused=ignore_unused,
-                **kwargs,
             ):
                 yield Match(compiled, match)
 
@@ -116,13 +111,10 @@ class Replus:
         exclude: list[str] | None = None,
         pos: int | None = None,
         endpos: int | None = None,
-        flags: int = 0,
         overlapped: bool = False,
         partial: bool = False,
         concurrent: bool | None = None,
         timeout: float | None = None,
-        ignore_unused: bool = False,
-        **kwargs: Any,
     ) -> list[Match]:
         """Return every match, sorted by position.
 
@@ -135,16 +127,16 @@ class Replus:
             exclude: Skip patterns of these types.
             pos: Start position of the matching.
             endpos: End position of the matching.
-            flags: Extra flags forwarded to :func:`regex.finditer`.
             overlapped: Allow overlapping matches (and skip overlap purging).
             partial: Allow partial matches.
             concurrent: Release the GIL while matching.
             timeout: Timeout in seconds for the matching.
-            ignore_unused: Ignore unused positional or keyword arguments in ``kwargs``.
-            **kwargs: Any further arguments accepted by :func:`regex.finditer`.
 
         Returns:
             The list of :class:`~replus.results.Match` objects, sorted by start offset.
+
+        Note:
+            Regex ``flags`` are a compile-time setting; see :meth:`finditer`.
         """
         matches = list(
             self.finditer(
@@ -153,13 +145,10 @@ class Replus:
                 exclude=exclude,
                 pos=pos,
                 endpos=endpos,
-                flags=flags,
                 overlapped=overlapped,
                 partial=partial,
                 concurrent=concurrent,
                 timeout=timeout,
-                ignore_unused=ignore_unused,
-                **kwargs,
             )
         )
         if not overlapped:

--- a/tests/test_replus.py
+++ b/tests/test_replus.py
@@ -35,6 +35,28 @@ def test_flags(models_dir: Path) -> None:
     assert len(engine_ii.parse("Today it's January 1st 1970")) == 0
 
 
+def test_flags_are_compile_time_only(engine: Replus) -> None:
+    # flags belong on the constructor; a per-call flags= is rejected loudly rather
+    # than forwarded to an already-compiled pattern (which regex refuses).
+    with pytest.raises(TypeError):
+        engine.parse("anything", flags=regex.IGNORECASE)  # ty: ignore[unknown-argument]
+    with pytest.raises(TypeError):
+        list(engine.finditer("anything", flags=regex.IGNORECASE))  # ty: ignore[unknown-argument]
+    with pytest.raises(TypeError):
+        engine.search("anything", flags=regex.IGNORECASE)
+    with pytest.raises(TypeError):
+        engine.sub("anything", {}, flags=regex.IGNORECASE)
+
+
+def test_unknown_runtime_kwarg_is_rejected(engine: Replus) -> None:
+    # ignore_unused / arbitrary **kwargs were never functional on a compiled pattern;
+    # a typo now surfaces as a TypeError instead of being silently swallowed.
+    with pytest.raises(TypeError):
+        engine.parse("anything", ignore_unused=True)  # ty: ignore[unknown-argument]
+    with pytest.raises(TypeError):
+        engine.search("anything", bogus_kwarg=["x"])
+
+
 def test_match(engine: Replus) -> None:
     matches = engine.parse("Today is january 1st 1970")
     assert len(matches) == 1


### PR DESCRIPTION
## What

The runtime `flags`, `ignore_unused`, and `**kwargs` parameters on `finditer`/`parse`/`search`/`sub` were never functional. `builder.py` compiles each pattern up front with `regex.compile(..., flags=...)`, and the `regex` module processes `flags`, `ignore_unused`, and named-list kwargs only at **compile time**. Forwarding them to an already-compiled pattern makes any non-zero `flags` raise `ValueError: cannot process flags argument with a compiled pattern`, while `ignore_unused` / extra kwargs are silently swallowed (the typo guard never fires, and named lists can never bind).

## How

- Call the compiled pattern's own bound `finditer()` with only the match-time arguments `regex` accepts there: `pos`, `endpos`, `overlapped`, `partial`, `concurrent`, `timeout`.
- Drop the three compile-time params from the runtime signatures. `flags` remains a construction-time argument (`Replus(..., flags=...)`), which is the only place it ever worked.
- Correct the docstrings and `quickstart.md` to stop advertising a per-call `flags` kwarg.
- Add regression tests asserting per-call `flags=` and unknown kwargs now raise `TypeError` loudly instead of failing cryptically or silently.

## Testing

All gates green: 78 tests pass, 100% line + branch coverage, `ruff check`, `ruff format`, `ty`, and `sphinx -W` docs build.

Found during a code review of the v1.0.0 revamp.
